### PR TITLE
chore: Implements M4 snapshot weights for onchain builders

### DIFF
--- a/results/S7/M4/weights/onchain__goldilocks.yaml
+++ b/results/S7/M4/weights/onchain__goldilocks.yaml
@@ -1,0 +1,48 @@
+# ----------------------------------------------------
+# Onchain Builders - Goldilocks - M4
+# ----------------------------------------------------
+
+data_snapshot:
+  data_dir: 'results/S7/M4/data/'
+  projects_file: 'onchain__project_metadata.csv'
+  metrics_file: 'onchain__metrics_by_project.csv'
+
+simulation:
+  periods:
+    previous: 'Apr 2025'
+    current: 'May 2025'
+  
+  eligibility_filter: true
+  
+  # Chain weights (1.0 = full weight)
+  chains:
+    base: 1.0
+    optimism: 1.0
+
+  tvl_minimum: 1000000
+  
+  # Metric weights must sum to 1.0
+  metrics:
+
+    # metrics used in M1
+    amortized_contract_invocations_monthly: 0.275
+    gas_fees_monthly: 0.275
+    average_tvl_monthly: 0.275
+
+    # user-related metrics available for weighting
+    active_farcaster_users_monthly: 0.0875
+    qualified_addresses_monthly: 0.0875
+
+  # Variant weights must sum to 1.0
+  metric_variants:
+    adoption: 0.20    # Current period value
+    growth: 0.20      # Change from previous period
+    retention: 0.60   # Minimum of current and previous
+
+  # Percentile cap for min-max scaling (100 = no cap)
+  percentile_cap: 98
+
+allocation:
+  budget: 1300000
+  min_amount_per_project: 200
+  max_share_per_project: 0.05


### PR DESCRIPTION
The weight of trusted user metrics is reduced from 25% to 17.5%. 
The other three metrics are incremented by 2.5% each.