### PR TITLE
fix: retroactive calculation for project affected by downtime from the attestation signer

### DIFF
--- a/results/S8/M7/outputs/onchain__results.json
+++ b/results/S8/M7/outputs/onchain__results.json
@@ -5835,5 +5835,23 @@
     "monthly_metrics":{
       "defillama_tvl":null
     }
-  }
+  },
+  {
+    "oso_project_id":"5W2V/EoUpbLReLyJGJCVGhpsrsGL3zryWyve0KOHuWg=",
+    "op_atlas_id":"0xc7104d126ffe628630e89f455711ef296175069fffb1f9c0e85b396ee1d23f27",
+    "display_name":"DIAMANTE",
+    "is_eligible":true,
+    "op_reward":2726.79,
+    "round_id":"8",
+    "eligibility_metrics":{
+      "transaction_count":5599297,
+      "active_days":65
+    },
+    "monthly_metrics":{
+      "defillama_tvl":null,
+      "gas_fees":0.010272537,
+      "active_addresses_aggregation":163306.0,
+      "contract_invocations":3264468.0
+    }
+  }  
 ]

--- a/results/S8/M8/outputs/onchain__results.json
+++ b/results/S8/M8/outputs/onchain__results.json
@@ -5980,5 +5980,23 @@
     "monthly_metrics":{
       "defillama_tvl":null
     }
+  },
+  {
+    "oso_project_id":"5W2V/EoUpbLReLyJGJCVGhpsrsGL3zryWyve0KOHuWg=",
+    "op_atlas_id":"0xc7104d126ffe628630e89f455711ef296175069fffb1f9c0e85b396ee1d23f27",
+    "display_name":"DIAMANTE",
+    "is_eligible":true,
+    "op_reward":2355.92,
+    "round_id":"8",
+    "eligibility_metrics":{
+      "transaction_count":9255540,
+      "active_days":95
+    },
+    "monthly_metrics":{
+      "defillama_tvl":null,
+      "gas_fees":0.1037995178,
+      "active_addresses_aggregation":180396.0,
+      "contract_invocations":3656243.0
+    }
   }
 ]


### PR DESCRIPTION
This PR includes simulated M7 and M8 rewards for the following project:
0xc7104d126ffe628630e89f455711ef296175069fffb1f9c0e85b396ee1d23f27

The project submitted its application during M7, but due to the OP Atlas attestation-signer drain incident, it remained stuck in a “pending” state instead of “submitted.” As a result, it did not receive rewards in M7 or M8.

We reconstruct the rewards the project would have earned had it been included in those months. To stay budget-neutral across M7–M9, the equivalent amount has been deducted from the M9 reward pool.